### PR TITLE
Updated cupy.util to cupy.memoize

### DIFF
--- a/PF-AFN_test/models/correlation/correlation.py
+++ b/PF-AFN_test/models/correlation/correlation.py
@@ -271,7 +271,7 @@ def cupy_kernel(strFunction, objVariables):
 	return strKernel
 # end
 
-@cupy.util.memoize(for_each_device=True)
+@cupy.memoize(for_each_device=True)
 def cupy_launch(strFunction, strKernel):
 	return cupy.cuda.compile_with_cache(strKernel).get_function(strFunction)
 # end

--- a/PF-AFN_train/models/correlation/correlation.py
+++ b/PF-AFN_train/models/correlation/correlation.py
@@ -271,7 +271,7 @@ def cupy_kernel(strFunction, objVariables):
 	return strKernel
 # end
 
-@cupy.util.memoize(for_each_device=True)
+@cupy.memoize(for_each_device=True)
 def cupy_launch(strFunction, strKernel):
 	return cupy.cuda.compile_with_cache(strKernel).get_function(strFunction)
 # end


### PR DESCRIPTION
On line 274, cupy.util is deprecated, updated it to cupy.memoize. This makes the code work with newer versions of cupy.